### PR TITLE
Hotkey Generator test case

### DIFF
--- a/java/test/edu/berkeley/cs/app/finalproject/HotKeyGenerator_T.java
+++ b/java/test/edu/berkeley/cs/app/finalproject/HotKeyGenerator_T.java
@@ -58,10 +58,22 @@ public class HotKeyGenerator_T {
   }
 
   @Test
-  public void testNoSolution() {
+  public void testNoSolutionSimple() {
     LinkedList<String> actions = new LinkedList<>();
     actions.insertFront("a");
     actions.insertFront("a");
+
+    HashMap<Character, String> result = hotKeyGenerator.generateHotKeys(actions);
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testNoSolutionComplex() {
+    LinkedList<String> actions = new LinkedList<>();
+    actions.insertFront("a");
+    actions.insertFront("b");
+    actions.insertFront("ab");
+    actions.insertFront("def");
 
     HashMap<Character, String> result = hotKeyGenerator.generateHotKeys(actions);
     Assert.assertTrue(result.isEmpty());


### PR DESCRIPTION
Add new "no solution" test case for Hotkey Generator. This covers a slightly more complicated case where a part of the actions list could have a solution and part of it cannot (example given: ["a", "b", "ab", "def"])